### PR TITLE
fix: update poetry dependency to use available/compatible version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ coverage/
 # poetry
 pip-wheel-metadata/
 setup.py
+
+# IDE specific
+.idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,5 @@ codecov = "*"
 
 [build-system]
 
-requires = ["poetry>=1.1.14"]
+requires = ["poetry~=1.1"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
## Related ticket:
None

## What this PR does?

- Fixes the incorrect dependency specification for poetry, The current version is specified for `poetry` is`>=1.1.14` which doesn't even exist yet (I looked around and I saw that the latest poetry version as of now is [1.1.12](https://python-poetry.org/history/)).
- Sets the dependency requirement to cater for all the minor&patch version updates for `1.x.x` instead of catering just patch versions.


## How to test?
- Try to install the package through `pip`. e.g. `pip install social-auth-mitxpro` directly from the main repo and it should be installed correctly
- Try to generate the package using `poetry build` and install `social-auth-mitxpro` from dist and it should still work.



## Background context:
- We did some changes in the poetry version when we upgraded the django version to 3.2 (https://github.com/mitodl/social-auth-mitxpro/pull/29). We specified the dependency for poetry to be `>=1.1.14` which doesn't exist. So this PR fixes that.
- As a result of above the package was no longer directly installable but it's dists still work as they can be generated through any installed poetry version